### PR TITLE
Adding date and time parameter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
+## [1.3.1] - 2025-10-03
+
+- Add `calendar_date` and `calendar_time_of_day` to allow setting date and time parameters
 
 ## [1.3.0] - 2025-06-17
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ gleam run   # Run the project
 gleam test  # Run the tests
 ```
 
+To run tests, a mysql instance must be running with the following parameters:
+
+* host: localhost
+* port: 3306
+* user: root
+* password: root
+* database: short_test
+
+You can start it using docker like this:
+
+```bash
+docker run -d --rm -p 3306:3306 -e MYSQL_ROOT_PASSWORD="root" -e MYSQL_DATABASE=shork_test mysql
+```
+
 ## Acknowlement
 
 This project is kindly supported by [binary butterfly](https://github.com/binary-butterfly).

--- a/gleam.toml
+++ b/gleam.toml
@@ -10,6 +10,7 @@ gleam_erlang = ">= 1.3.0 and < 2.0.0"
 gleam_stdlib = ">= 0.65.0 and < 1.0.0"
 mysql = ">= 1.9.0 and < 2.0.0"
 gleam_otp = ">= 1.2.0 and < 2.0.0"
+gleam_time = ">= 1.4.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,6 +5,7 @@ packages = [
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_stdlib", version = "0.65.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "7C69C71D8C493AE11A5184828A77110EB05A7786EBF8B25B36A72F879C3EE107" },
+  { name = "gleam_time", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "DCDDC040CE97DA3D2A925CDBBA08D8A78681139745754A83998641C8A3F6587E" },
   { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
   { name = "mysql", version = "1.9.0", build_tools = ["make", "rebar3", "mix"], requirements = [], otp_app = "mysql", source = "hex", outer_checksum = "186D7E6DF9CAD33BD9F8F61856F45F2F1962F80B645F163DA744F66C626DA63E" },
 ]
@@ -13,5 +14,6 @@ packages = [
 gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.65.0 and < 1.0.0" }
+gleam_time = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 mysql = { version = ">= 1.9.0 and < 2.0.0" }


### PR DESCRIPTION
I would like to be able to insert date and time paremters using shork. Since mysql-otp already supports that, one just has to create the correct paramter values, which are:

`{Year, Month, Day}` for Dates.
`{Days, {Hours, Minutes, Seconds}}` for Times (where Seconds is a float).

The `calendar_time_of_day` parameter function just sets `Days` to 0, but since mysql-otp just re-intergrates that into the hours ([see here](https://github.com/mysql-otp/mysql-otp/blob/1afd59677b3e2daf795f5fd77268e1dbc20f4c51/src/mysql_encode.erl#L40)), that should be fine.

This implemention is based on the Implementation in [pog](https://github.com/lpil/pog/blob/34b184b53579cf0262bfcd789102d867ff0e4f39/src/pog.gleam#L401)

Pog also has decoder for date and times, maybe those should also be part of shork? I hesitate, because there are no decorders so far ...